### PR TITLE
feat(spot): lista PDF completa e ordinata (19 voci)

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,17 +62,27 @@
   </div>
 
 <script>
-  // Elenco PDF (placeholder) — modifica i path in /docs/
+  // Lista PDF completa e ordinata (19 voci)
   const PDFS = [
-    ["Hub Nazionale del Commercio","./docs/hub-nazionale.pdf"],
-    ["DMS & CLUST-ER","./docs/dms-cluster.pdf"],
-    ["DMS — Riaccendiamo i Mercati","./docs/riaccendiamo.pdf"],
-    ["Dossier Nazionale","./docs/dossier.pdf"],
+    ["Hub Nazionale del Commercio","./docs/hub-nazionale-commercio.pdf"],
+    ["DMS & CLUST-ER","./docs/dms-clust-er.pdf"],
+    ["DMS — Riaccendiamo i Mercati","./docs/riaccendiamo-mercati.pdf"],
+    ["Dossier Nazionale","./docs/dossier-nazionale.pdf"],
+    ["DMS ECC (narrativo)","./docs/dms-ecc-narrativo.pdf"],
+    ["DMS ECC 2 (tecnico)","./docs/dms-ecc-2-tecnico.pdf"],
+    ["Carbon Credit – Logica","./docs/carbon-credit-logica.pdf"],
     ["Equilibrio Ecosostenibile","./docs/equilibrio-ecosostenibile.pdf"],
-    ["Progetto Nazionale","./docs/progetto-nazionale.pdf"],
     ["Passaporto EU","./docs/passaporto-eu.pdf"],
+    ["DPP Explained","./docs/dpp-explained.pdf"],
+    ["Scenario Futuro","./docs/scenario-futuro.pdf"],
+    ["Gemello DMS","./docs/gemello-dms.pdf"],
+    ["Ecosistema Costi PA","./docs/ecosistema-costi-pa.pdf"],
+    ["Analisi & Soluzione","./docs/analisi-soluzione.pdf"],
+    ["Progetto Nazionale","./docs/progetto-nazionale.pdf"],
     ["Presentazione DMS (Compressa)","./docs/presentazione-dms-compressa.pdf"],
-    ["Città Metropolitana di Bologna","./docs/citta-metropolitana-bologna.pdf"]
+    ["Città Metropolitana di Bologna","./docs/citta-metropolitana-bologna.pdf"],
+    ["HUB URBANI E DI PROSSIMITÀ","./docs/hub-urbani-prossimita.pdf"],
+    ["Hub Urbani e di Prossimità in Emilia-Romagna","./docs/hub-urbani-prossimita-er.pdf"]
   ];
   const list = document.getElementById('docs');
   PDFS.forEach(([title,href])=>{


### PR DESCRIPTION
Lista PDF completa e ordinata per pagina SPOT.

**Modifiche:**
- ✅ Aggiornata da 9 a 19 voci PDF seguendo ordine roadmap
- ✅ Nomi file standardizzati in kebab-case
- ✅ Mantenuto layout colonna sinistra + video destra
- ✅ Target _blank per apertura in nuova scheda
- ✅ Lista ordinata: Hub Nazionale → DMS & CLUST-ER → ... → Hub Urbani ER

**Test:**
- Ogni link apre in nuova scheda
- Layout responsive mantenuto
- Video player invariati