### PR TITLE
feat(theme): apply dark-green palette across home/spot/mindmap

### DIFF
--- a/assets/theme-green.css
+++ b/assets/theme-green.css
@@ -1,0 +1,15 @@
+:root{
+  /* Fondo: verde scuro elegante (vecchia Spot) */
+  --bg-a:#071a1d;         /* più scuro */
+  --bg-b:#0b2730;         /* verde petrolio */
+  /* Testi */
+  --ink:#e8fbff;          /* testo principale chiaro */
+  --muted:#9bd6de;        /* testo secondario */
+  /* Pannelli e bordi */
+  --panel:rgba(7,26,29,.78);
+  --stroke:rgba(173,234,240,.18);
+  /* Accenti */
+  --accent:#14b8a6;       /* teal DMS */
+  --accent2:#0b5fff;      /* blu accessorio (se usato) */
+}
+

--- a/home.html
+++ b/home.html
@@ -142,6 +142,7 @@
   #viewport     { z-index: 3; box-shadow: 0 18px 40px rgba(0,0,0,.40); }
   .node         { z-index: 4; }
 </style>
+<link rel="stylesheet" href="./assets/theme-green.css">
 </head>
 <body>
   <div id="glowLayer" aria-hidden="true"></div> <!-- spotlight mouse -->

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   video{width:100%; border-radius:12px; border:1px solid rgba(255,255,255,.18); display:block}
   @media (max-width:900px){ .wrap{grid-template-columns: 1fr} }
 </style>
+<link rel="stylesheet" href="./assets/theme-green.css">
 </head>
 <body>
   <div class="top">

--- a/mindmap.html
+++ b/mindmap.html
@@ -32,6 +32,7 @@
   .link{ stroke:rgba(255,255,255,.35); stroke-width:1.2; fill:none }
   a rect.node{ cursor:pointer }
 </style>
+<link rel="stylesheet" href="./assets/theme-green.css">
 </head>
 <body>
   <div class="top">


### PR DESCRIPTION
Tema Verde Scuro Elegante per tutte e 3 le pagine.

**Approccio Ultra-Sicuro:**
- ✅ File CSS separato (theme-green.css) 
- ✅ Override solo variabili CSS, nessun JS/markup toccato
- ✅ Link dopo stili inline per corretta sovrascrittura
- ✅ Layering e funzionalità invariate
- ✅ Rollback immediato: rimuovere <link> o file

**Colori:**
- ✅ Fondo: verde scuro elegante (#071a1d, #0b2730)
- ✅ Testi: chiaro (#e8fbff) e secondario (#9bd6de)
- ✅ Accenti: teal DMS (#14b8a6)

**Test:**
- Home: video e glow come prima, colori aggiornati
- Spot: layout invariato, palette verde
- Mappa: hub e nodi funzionanti, tema applicato