### PR TITLE
feat(theme): force dark-green palette via inline override on all pages

### DIFF
--- a/home.html
+++ b/home.html
@@ -143,6 +143,29 @@
   .node         { z-index: 4; }
 </style>
 <link rel="stylesheet" href="./assets/theme-green.css">
+<!-- THEME GREEN OVERRIDE (safe, removable) -->
+<style id="theme-green">
+  :root{
+    /* Fondo: verde scuro elegante */
+    --bg-a:#071a1d;
+    --bg-b:#0b2730;
+    /* Testi */
+    --ink:#e8fbff;
+    --muted:#9bd6de;
+    /* Pannelli e bordi */
+    --panel:rgba(7,26,29,.78);
+    --stroke:rgba(173,234,240,.18);
+    /* Accenti */
+    --accent:#14b8a6;
+    --accent2:#0b5fff;
+  }
+  /* Forziamo lo sfondo a usare le variabili sopra */
+  body{
+    background:
+      radial-gradient(1200px 800px at 20% -10%, rgba(20,184,166,.08), transparent 60%),
+      linear-gradient(180deg, var(--bg-b), var(--bg-a)) !important;
+  }
+</style>
 </head>
 <body>
   <div id="glowLayer" aria-hidden="true"></div> <!-- spotlight mouse -->

--- a/index.html
+++ b/index.html
@@ -33,6 +33,29 @@
   @media (max-width:900px){ .wrap{grid-template-columns: 1fr} }
 </style>
 <link rel="stylesheet" href="./assets/theme-green.css">
+<!-- THEME GREEN OVERRIDE (safe, removable) -->
+<style id="theme-green">
+  :root{
+    /* Fondo: verde scuro elegante */
+    --bg-a:#071a1d;
+    --bg-b:#0b2730;
+    /* Testi */
+    --ink:#e8fbff;
+    --muted:#9bd6de;
+    /* Pannelli e bordi */
+    --panel:rgba(7,26,29,.78);
+    --stroke:rgba(173,234,240,.18);
+    /* Accenti */
+    --accent:#14b8a6;
+    --accent2:#0b5fff;
+  }
+  /* Forziamo lo sfondo a usare le variabili sopra */
+  body{
+    background:
+      radial-gradient(1200px 800px at 20% -10%, rgba(20,184,166,.08), transparent 60%),
+      linear-gradient(180deg, var(--bg-b), var(--bg-a)) !important;
+  }
+</style>
 </head>
 <body>
   <div class="top">

--- a/mindmap.html
+++ b/mindmap.html
@@ -33,6 +33,29 @@
   a rect.node{ cursor:pointer }
 </style>
 <link rel="stylesheet" href="./assets/theme-green.css">
+<!-- THEME GREEN OVERRIDE (safe, removable) -->
+<style id="theme-green">
+  :root{
+    /* Fondo: verde scuro elegante */
+    --bg-a:#071a1d;
+    --bg-b:#0b2730;
+    /* Testi */
+    --ink:#e8fbff;
+    --muted:#9bd6de;
+    /* Pannelli e bordi */
+    --panel:rgba(7,26,29,.78);
+    --stroke:rgba(173,234,240,.18);
+    /* Accenti */
+    --accent:#14b8a6;
+    --accent2:#0b5fff;
+  }
+  /* Forziamo lo sfondo a usare le variabili sopra */
+  body{
+    background:
+      radial-gradient(1200px 800px at 20% -10%, rgba(20,184,166,.08), transparent 60%),
+      linear-gradient(180deg, var(--bg-b), var(--bg-a)) !important;
+  }
+</style>
 </head>
 <body>
   <div class="top">


### PR DESCRIPTION
Override tema verde scuro a prova di cache.

**Approccio Cache-Proof:**
- ✅ Override inline con <style id="theme-green"> in tutte e 3 le pagine
- ✅ Più forte di file CSS esterni, ignora cache browser
- ✅ Nessuna modifica JS/markup, solo CSS variables
- ✅ Rollback immediato: rimuovere i blocchi <style>

**Colori Forzati:**
- ✅ Fondo: verde scuro (#071a1d, #0b2730)
- ✅ Testi: chiaro (#e8fbff) e secondario (#9bd6de)
- ✅ Accenti: teal (#14b8a6)
- ✅ Gradiente radiale con accento teal per profondità

**Test con ?v=green2 per cache-bust immediato**